### PR TITLE
Replace prod with min.

### DIFF
--- a/addParts.m
+++ b/addParts.m
@@ -27,7 +27,7 @@ for i=1:n
     contexts{i}.pos = p;  
     sz=round(par(3:4,i)');
     
-    if prod(sz > [15 15]) > 0 && prod(sz < 0.6*size(im)) > 0
+    if min(sz > [15 15]) > 0 && min(sz < 0.6*size(im)) > 0
         contexts{i}.target_sz =sz; %target_sz - [factor*target_sz(1) factor*target_sz(2)];
     else
         contexts{i}.target_sz = ceil([min(target_sz) min(target_sz)]);

--- a/inBox.m
+++ b/inBox.m
@@ -10,7 +10,7 @@ function b=inBox(WinSize,pos,p,rate)
     BoundUR = pos + rate*WinSize/2;
     BoundDL = pos - rate*WinSize/2;
 
-    if prod(p<BoundUR)*prod(  p > BoundDL) ==0
+    if min(p < BoundUR) * min(p > BoundDL) == 0
         b=false;
     else
         b=true;

--- a/resetParts.m
+++ b/resetParts.m
@@ -198,7 +198,7 @@ end
 
 function b=outImage(WinSize,p)
 
-    if prod(p<WinSize-[1 1])*prod(  p > [2 2]) >0
+    if min(p < WinSize - [1 1]) * min(p > [2 2]) > 0
         b=false;
     else
         b=true;

--- a/voting.m
+++ b/voting.m
@@ -40,7 +40,7 @@ function  [position,target_sz] = voting(pos,target_sz,contexts,scale);%neighborC
         position = psr*points;
 %      pos = pos /nn;
     end
-                    if prod(~isnan(position)) ==0
+                if min(~isnan(position)) == 0
                     position=[0 0];
                 end
 %     [mx,ix]=max(points);


### PR DESCRIPTION
The prod as used in the functions is equivalent with min. That is to check if any of the dimensions is 0.
The reason for change, apart from performance-wise, is that in versions older than MATLAB 2012b, the prod raises an error.
